### PR TITLE
initStore fix

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,5 +1,6 @@
 import { Provider } from 'react-redux'
 import { Router } from 'common/router'
+import { CheckCache } from 'ds-cache'
 import { hot } from 'react-hot-loader'
 import routes from './routes'
 
@@ -7,7 +8,9 @@ import routes from './routes'
 function AppProvider({ store, history }) {
   return (
     <Provider store={store}>
-      <Router history={history} routes={routes}/>
+      <CheckCache>
+        <Router history={history} routes={routes}/>
+      </CheckCache>
     </Provider>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2822,7 +2822,7 @@ dotenv@^6.0.0:
 
 "ds-cache@https://github.com/django-stars/ds-fe-cache":
   version "1.0.0"
-  resolved "https://github.com/django-stars/ds-fe-cache#e19e609e2c065bbaba0907d4d352f5706c0f6256"
+  resolved "https://github.com/django-stars/ds-fe-cache#c027dbf110991c8fb07b6036d9052098d4196c19"
 
 "ds-redux-helpers@https://github.com/django-stars/ds-redux-helpers":
   version "1.0.0"


### PR DESCRIPTION
this is because our checkaccess functionality works based on router navigation and we should initialize store sync for web apps instead of react-native apps. Or add global loading wrapper that will render some spinner instead of routerRecursive before INIT action