### PR TITLE
Add padding-line-between-statements rule to eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,6 +50,11 @@
     "react/prop-types": ["error"],
     "react/require-default-props": ["error"],
     "react/display-name": ["off", { "ignoreTranspilerName": true }],
-    "jsx-quotes": ["error", "prefer-double"]
+    "jsx-quotes": ["error", "prefer-double"],
+    "padding-line-between-statements": [
+      "error",
+      { "blankLine": "always", "prev": "block", "next": "*" },
+      { "blankLine": "always", "prev": "block-like", "next": "*" }
+    ]
   }
 }


### PR DESCRIPTION
Added rule to eslint that requires the padding line after block-like statements (`if`, `for`, `while`, etc.). It makes code more readable, especially when there are a lot of block statements one after another.
```
// Wrong

if(true) {
  // code
}
for(let i = 0; i < 100; i++) {
  // code
}
while(true) {
  // code
}
```
```
// Correct

if(true) {
  // code
}

for(let i = 0; i < 100; i++) {
  // code
}

while(true) {
  // code
}
```