### PR TITLE
Fix filling of location state

### DIFF
--- a/src/app/common/router/withRouter.js
+++ b/src/app/common/router/withRouter.js
@@ -16,7 +16,7 @@ export default function withNamedRouter(ChildComponent) {
       ...routerValue.location,
       state: {
         ...(get(routerValue.location, 'state', {})),
-        name: findKey(namedRoutes, key => match(key)(routerValue.location.pathname)),
+        name: findKey(namedRoutes, key => match(key && key.replace(/\/$/, ''))(routerValue.location.pathname)),
       },
     }
     const history = useMemo(() => namedHistory(routerValue.history, namedRoutes), [routerValue])


### PR DESCRIPTION
Pathanames can be in two formats: `/path` and `/path/`. Previous implementation covered only the first case and ignored the second one. Added removal of trailing slash of pathname.